### PR TITLE
chore: orgCode optional for functions wrapping getAssetUrl

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -407,7 +407,7 @@ export const getKindeSignInUrl = (): KindePlaceholder => loginGUID;
  *
  * @returns Light Mode Logo Placeholder
  */
-export const getLogoUrl = (orgCode: OrgCode) => {
+export const getLogoUrl = (orgCode?: OrgCode) => {
   return getAssetUrl("logo", orgCode);
 };
 
@@ -415,7 +415,7 @@ export const getLogoUrl = (orgCode: OrgCode) => {
  *
  * @returns Dark Mode Logo Placeholder
  */
-export const getDarkModeLogoUrl = (orgCode: OrgCode) => {
+export const getDarkModeLogoUrl = (orgCode?: OrgCode) => {
   return getAssetUrl("logo_dark", orgCode);
 };
 
@@ -423,7 +423,7 @@ export const getDarkModeLogoUrl = (orgCode: OrgCode) => {
  *
  * @returns SVG FavIcon Placeholder
  */
-export const getSVGFavicon = (orgCode: OrgCode) => {
+export const getSVGFavicon = (orgCode?: OrgCode) => {
   return getAssetUrl("favicon_svg", orgCode);
 };
 
@@ -431,7 +431,7 @@ export const getSVGFavicon = (orgCode: OrgCode) => {
  *
  * @returns Fallback FavIcon Placeholder
  */
-export const getFallbackFavicon = (orgCode: OrgCode) => {
+export const getFallbackFavicon = (orgCode?: OrgCode) => {
   return getAssetUrl("favicon_fallback", orgCode);
 };
 


### PR DESCRIPTION
# Explain your changes
- made `orgCode` optional param for functions that wrap `getAssetUrl`
- `getLogoUrl`, `getDarkModeLogoUrl`, `getSVGFavicon`, `getFallbackFavicon`
# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
