### PR TITLE
feat: add support for `onExistingPasswordProvided` workflow event

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -28,10 +28,20 @@ const getAssetUrl = (assetPath: string, orgCode?: OrgCode) => {
 declare namespace kinde {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export function fetch(url: string, options: unknown): Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function secureFetch(url: string, options: unknown): Promise<any>;
 
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace env {
     export function get(key: string): { value: string; isSecret: boolean };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace widget {
+    export function invalidateFormField(
+      fieldName: string,
+      message: string,
+    ): void;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -231,8 +241,21 @@ export function denyAccess(reason: string) {
 }
 
 /**
+ * Invalidate a Kinde widget form field
+ * @param fieldName Name of the field to invalidate
+ * @param message Reason for invalidating the field
+ */
+export function invalidateFormField(fieldName: string, message: string) {
+  if (!kinde.widget) {
+    throw new Error("widget binding not available");
+  }
+  kinde.widget.invalidateFormField(fieldName, message);
+}
+
+/**
  * Fetch data from an external API
- * @param reason Reason for denying access
+ * @param url URL of the API
+ * @param options Fetch options
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function fetch<T = any>(
@@ -241,6 +264,33 @@ export async function fetch<T = any>(
 ): Promise<T> {
   if (!kinde.fetch) {
     throw new Error("fetch binding not available");
+  }
+
+  if (!options.responseFormat) {
+    options.responseFormat = "json";
+  }
+
+  const result = await kinde.fetch(url, options);
+
+  return {
+    data: result?.json,
+  } as T;
+}
+
+/**
+ * Fetch data from a secure external API
+ *
+ * Encryption keys can be setup in the Kinde dashboard under workflows > encryption keys
+ * @param url URL of the API
+ * @param options Fetch options
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function secureFetch<T = any>(
+  url: string,
+  options: KindeFetchOptions,
+): Promise<T> {
+  if (!kinde.secureFetch) {
+    throw new Error("secureFetch binding not available");
   }
 
   if (!options.responseFormat) {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -297,7 +297,7 @@ export async function secureFetch<T = any>(
     options.responseFormat = "json";
   }
 
-  const result = await kinde.fetch(url, options);
+  const result = await kinde.secureFetch(url, options);
 
   return {
     data: result?.json,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,14 @@ export type WorkflowSettings = {
      */
     "kinde.fetch"?: {};
     /**
+     * Exposes the fetch method to call signed extenal APIs to the workflow
+     */
+    "kinde.secureFetch"?: {};
+    /**
+     * Exposes the fetch method to call access the manipulate the Kinde widget
+     */
+    "kinde.widget"?: {};
+    /**
      * Exposes access to the kinde environment variables
      */
     "kinde.env"?: {};
@@ -77,11 +85,13 @@ export type WorkflowSettings = {
 export enum WorkflowTrigger {
   UserTokenGeneration = "user:tokens_generation",
   M2MTokenGeneration = "m2m:token_generation",
+  ExistingPasswordProvided = "user:existing_password_provided",
 }
 
 export type WorkflowEvents =
   | onUserTokenGeneratedEvent
-  | onM2MTokenGeneratedEvent;
+  | onM2MTokenGeneratedEvent
+  | onExistingPasswordProvided;
 
 type EventBase = {
   request: RequestContext;
@@ -118,6 +128,20 @@ export type onUserTokenGeneratedEvent = EventBase & {
     };
     organization: {
       code: string;
+    };
+  };
+};
+
+export type onExistingPasswordProvided = EventBase & {
+  context: {
+    auth: {
+      password: string;
+    };
+    user: {
+      id: string;
+    };
+    workflow: {
+      trigger: WorkflowTrigger.ExistingPasswordProvided;
     };
   };
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,11 +52,11 @@ export type WorkflowSettings = {
      */
     console?: {};
     /**
-     * Exposes the fetch method to call extenal APIs to the workflow
+     * Exposes the fetch method to call external APIs to the workflow
      */
     "kinde.fetch"?: {};
     /**
-     * Exposes the fetch method to call signed extenal APIs to the workflow
+     * Exposes the fetch method to call signed external APIs to the workflow
      */
     "kinde.secureFetch"?: {};
     /**


### PR DESCRIPTION
# Explain your changes

Add support for `onExistingPasswordProvided` which includes

`kinde.secureFetch` and `kinde.widget` support

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
