### PR TITLE
fix: kinde fetch return text return type

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -273,7 +273,10 @@ export async function fetch<T = any>(
   const result = await kinde.fetch(url, options);
 
   return {
-    data: result?.json,
+    data:
+      options.responseFormat === "json"
+        ? result?.json
+        : (result.text as string),
   } as T;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -174,7 +174,7 @@ export type onM2MTokenGeneratedEvent = EventBase & {
 
 export type KindeFetchOptions = {
   method: "POST" | "GET" | "PUT" | "DELETE" | "PATCH";
-  responseFormat?: "json";
+  responseFormat?: "json" | "text";
   headers: Record<string, string>;
   body?: URLSearchParams;
 };


### PR DESCRIPTION
# Explain your changes

Fetch didn't work correctly when using `responseType: 'text"`

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
