### PR TITLE
fix: passing body to non get fetch methods

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -384,6 +384,12 @@ export async function createKindeAPI(
     params,
     contentType = "application/json",
   }: KindeAPIRequest) => {
+    let body;
+
+    if (params) {
+      body = method === "GET" ? new URLSearchParams(params) : params;
+    }
+
     const result = await kinde.fetch(
       `${event.context.domains.kindeDomain}/api/v1/${endpoint}`,
       {
@@ -394,7 +400,7 @@ export async function createKindeAPI(
           "Content-Type": contentType,
           accept: "application/json",
         },
-        body: params && new URLSearchParams(params),
+        body,
       },
     );
 


### PR DESCRIPTION
# Explain your changes

When the method was anything other than GET the params payload was incorrectly converted to query params which caused the POST/PUT/PATCH methods not to work.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
