### PR TITLE
feat: option to skip cache on M2M token

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -367,12 +367,55 @@ export type getM2MTokenOptions = {
   audience: string[];
   scopes?: string[];
   headers?: Record<string, string>;
+  skipCache?: boolean;
 };
 
 export async function getM2MToken<T = string>(
   tokenName: T,
   options: getM2MTokenOptions,
 ) {
+  const fetchToken = () => {
+    if (!options.domain || !options.clientId || !options.clientSecret) {
+      throw new Error("getM2MToken: Missing required parameters");
+    }
+
+    try {
+      const result = kinde.fetch(`${options.domain}/oauth2/token`, {
+        method: "POST",
+        responseFormat: "json",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          accept: "application/json",
+          ...options.headers,
+        },
+        body: new URLSearchParams({
+          audience: options.audience?.join(" ") ?? "",
+          grant_type: "client_credentials",
+          client_id: options.clientId,
+          client_secret: options.clientSecret,
+          scope: options.scopes?.join(" ") ?? "",
+        }),
+      }) as { json: { access_token: string } };
+
+      if (!result.json?.access_token) {
+        throw new Error("getM2MToken: No access token returned");
+      }
+
+      console.log("returning token: ", result.json.access_token);
+      return result.json.access_token;
+    } catch (error) {
+      throw new Error(
+        `getM2MToken: Failed to obtain token - ${(error as Error).message}`,
+      );
+    }
+  };
+
+  // If skipCache is true, directly fetch the token without using cache
+  if (options.skipCache) {
+    return fetchToken();
+  }
+
+  // Otherwise, use the cache with onMissingOrExpired callback
   return await kinde.cache.jwtToken(tokenName as string, {
     validation: {
       key: {
@@ -382,39 +425,7 @@ export async function getM2MToken<T = string>(
         },
       },
     },
-    onMissingOrExpired: () => {
-      if (!options.domain || !options.clientId || !options.clientSecret) {
-        throw new Error("getM2MToken: Missing required parameters");
-      }
-
-      try {
-        const result = kinde.fetch(`${options.domain}/oauth2/token`, {
-          method: "POST",
-          responseFormat: "json",
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            accept: "application/json",
-            ...options.headers,
-          },
-          body: new URLSearchParams({
-            audience: options.audience?.join(" ") ?? "",
-            grant_type: "client_credentials",
-            client_id: options.clientId,
-            client_secret: options.clientSecret,
-            scope: options.scopes?.join(" ") ?? "",
-          }),
-        }) as { json: { access_token: string } };
-
-        if (!result.json?.access_token) {
-          throw new Error("getM2MToken: No access token returned");
-        }
-        return result.json.access_token;
-      } catch (error) {
-        throw new Error(
-          `getM2MToken: Failed to obtain token - ${(error as Error).message}`,
-        );
-      }
-    },
+    onMissingOrExpired: fetchToken,
   });
 }
 
@@ -453,7 +464,7 @@ export async function createKindeAPI(
     }
   }
 
-  const token = await getM2MToken("internal_m2m_access_token", {
+  let token = await getM2MToken("internal_m2m_access_token", {
     domain: event.context.domains.kindeDomain,
     clientId,
     clientSecret,

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -401,7 +401,6 @@ export async function getM2MToken<T = string>(
         throw new Error("getM2MToken: No access token returned");
       }
 
-      console.log("returning token: ", result.json.access_token);
       return result.json.access_token;
     } catch (error) {
       throw new Error(
@@ -470,6 +469,12 @@ export async function createKindeAPI(
     clientSecret,
     audience: [`${event.context.domains.kindeDomain}/api`],
   });
+
+  if (typeof token === "object") {
+    token = JSON.stringify(token);
+    token = token.replace(`"\\"`, "");
+    token = token.replace(`\\""`, "");
+  }
 
   const callKindeAPI = async ({
     method,


### PR DESCRIPTION
# Explain your changes

option to skip the cache on M2M tokens and fix for where the token is not string from cache

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
