### PR TITLE
fix(build): target es2019 for runtime bundle output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       name: "@kinde/infrastructure",
       fileName: "infrastructure",
     },
-    target: "esnext",
+    target: "es2019",
     outDir: "../dist",
     emptyOutDir: true,
   },


### PR DESCRIPTION
## Summary

The Vite build was targeting `esnext`, which caused the bundler to emit ES2021 syntax (notably logical assignment operators like `||=`) in the published bundle. The Kinde Workflow runtime does not support that syntax, so workflow code using this package could fail at runtime.

This change lowers the build target to `es2019`, which downlevels logical assignment, optional chaining, and nullish coalescing to syntax Goja can execute.

## Changes

- **`vite.config.ts`**: change `build.target` from `esnext` to `es2019`

## Before / after (bundle output)

With `esnext`, the build emitted:

```js
t.responseFormat ||= "json";
```

With `es2019`, the equivalent downleveled output is:

```js
t.responseFormat || (t.responseFormat = "json");
```
