### PR TITLE
feat: add switch connection JS

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -561,6 +561,13 @@ export const getKindeCSRF = (): KindePlaceholder =>
 
 /**
  *
+ * @returns Kinde placeholder for the CSRF token
+ */
+export const getKindeSwitchJS = (): KindePlaceholder =>
+  "@bc178a068813415ca4760fc31a8bdb01@";
+
+/**
+ *
  * @returns Register URL Placeholder
  */
 export const getKindeRegisterUrl = (): KindePlaceholder => registerGUID;


### PR DESCRIPTION
## Summary

Adds a new custom-page placeholder helper so authors can include Kinde’s switch-connection JavaScript on authentication pages.

## Motivation

Custom pages that let users switch between auth providers (e.g. social login vs email/password) need the platform-provided switch-connection script loaded on the page. Other platform assets already have dedicated placeholders in `@kinde/infrastructure` (e.g. `getKindeRequiredJS`, `getKindeCSRF`). This change adds the equivalent placeholder for switch-connection JS so custom page templates can include it consistently.

## Changes

- **`getKindeSwitchJS()`** in `lib/main.ts` — returns the Kinde placeholder `@bc178a068813415ca4760fc31a8bdb01@`, following the same pattern as existing custom-page helpers.

## Usage

```ts
import { getKindeSwitchJS } from "@kinde/infrastructure";

// In a custom page template
getKindeSwitchJS();
```
